### PR TITLE
Fix Wayland keybindings with multiple layouts

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@ Qtile x.xx.x, released xxxx-xx-xx:
     * bugfixes
         - `window.can_steal_focus = False` should be set in a `group_window_add` instead of the previously recommended `client_new` hook.
         - Fix Xwayland popup windows that fail to reappear #5155
+        - Wayland: retain keybindings when switching keyboard layouts
 
 Qtile 0.31.0, released 2025-03-07:
     !!! breaking changes !!!

--- a/libqtile/backend/wayland/inputs.py
+++ b/libqtile/backend/wayland/inputs.py
@@ -272,11 +272,14 @@ class Keyboard(_Device):
         if not self.core.exclusive_client:
             # translate libinput keycode -> xkbcommon
             keycode = event.keycode + 8
-            layout_index = lib.xkb_state_key_get_layout(self.keyboard._ptr.xkb_state, keycode)
+            # Use the first layout when resolving keysyms so that keybindings
+            # remain consistent regardless of the active keyboard layout.  This
+            # mirrors the behaviour of the X11 backend where keycodes are
+            # grabbed based on the initial layout only.
             nsyms = lib.xkb_keymap_key_get_syms_by_level(
                 self.keyboard._ptr.keymap,
                 keycode,
-                layout_index,
+                0,
                 0,
                 xkb_keysym,
             )

--- a/test/backend/wayland/test_keyboard_layout.py
+++ b/test/backend/wayland/test_keyboard_layout.py
@@ -1,0 +1,61 @@
+import types
+import pytest
+
+pytest.importorskip("pywayland")
+pytest.importorskip("xkbcommon")
+
+from libqtile.backend.wayland.inputs import Keyboard, KEY_PRESSED, lib
+
+
+def test_bindings_use_first_layout(monkeypatch):
+    """Ensure first layout is used when resolving keysyms."""
+
+    called_layout = None
+
+    def fake_get_syms(keymap, keycode, layout_index, level, syms):
+        nonlocal called_layout
+        called_layout = layout_index
+        return 0
+
+    monkeypatch.setattr(lib, "xkb_keymap_key_get_syms_by_level", fake_get_syms)
+
+    core = types.SimpleNamespace(
+        qtile=types.SimpleNamespace(
+            process_key_event=lambda *a, **k: (None, False),
+            call_later=lambda *a, **k: None,
+        ),
+        seat=types.SimpleNamespace(
+            keyboard_notify_key=lambda *a: None,
+            keyboard_notify_modifiers=lambda *a: None,
+            set_keyboard=lambda *a: None,
+        ),
+        idle=types.SimpleNamespace(notify_activity=lambda *a: None),
+        exclusive_client=False,
+        keyboards=[],
+        grabbed_keys=set(),
+    )
+
+    device = types.SimpleNamespace(
+        destroy_event=None,
+        type=types.SimpleNamespace(name="keyboard"),
+        name="kbd",
+        vendor=1,
+        product=1,
+        libinput_get_device_handle=lambda: None,
+    )
+
+    keyboard = types.SimpleNamespace(
+        _ptr=types.SimpleNamespace(
+            keymap=object(),
+            repeat_info=types.SimpleNamespace(rate=0, delay=0),
+        ),
+        modifier=0,
+        set_repeat_info=lambda *a, **k: None,
+        set_keymap=lambda *a, **k: None,
+    )
+
+    k = Keyboard(core, device, keyboard)
+    event = types.SimpleNamespace(keycode=10, state=KEY_PRESSED)
+    k._on_key(None, event)
+
+    assert called_layout == 0


### PR DESCRIPTION
## Summary
- grab keysyms from first layout to keep bindings active after layout switches
- test that Wayland keyboard layout handling uses layout index 0
- document fix in CHANGELOG

## Testing
- `pre-commit run --files libqtile/backend/wayland/inputs.py CHANGELOG test/backend/wayland/test_keyboard_layout.py` *(fails: command not found)*
- `pytest -k test_keyboard_layout -vv` *(fails: command not found)*