### PR TITLE
Add group glueing

### DIFF
--- a/docs/manual/config/lazy.rst
+++ b/docs/manual/config/lazy.rst
@@ -100,6 +100,10 @@ Group functions
         Takes an optional ``toggle`` parameter (defaults to False).
         If this group is already on the screen, it does nothing by default;
         to toggle with the last used group instead, use ``toggle=True``.
+    * - ``lazy.group["group_name"].glue_group("other")``
+      - Move all windows from the group called ``other`` to ``group_name``.
+    * - ``lazy.group["group_name"].unglue_group()``
+      - Return windows glued to ``group_name`` back to their original group.
     * - ``lazy.layout.increase_ratio()``
       - Increase the space for master window at the expense of slave windows
     * - ``lazy.layout.decrease_ratio()``

--- a/libqtile/group.py
+++ b/libqtile/group.py
@@ -35,6 +35,7 @@ from libqtile.command.base import CommandObject, expose_command
 from libqtile.log_utils import logger
 
 if TYPE_CHECKING:
+    from libqtile.backend.base import Window
     from libqtile.command.base import ItemT
 
 
@@ -67,6 +68,7 @@ class _Group(CommandObject):
         self.current_layout = None
         self.last_focused = None
         self.persist = persist
+        self.glue_map: dict[Window, _Group] = {}
 
     def _configure(self, layouts, floating_layout, qtile):
         self.screen = None
@@ -578,5 +580,31 @@ class _Group(CommandObject):
         self.label = label if label is not None else self.name
         hook.fire("changegroup")
 
+    @expose_command()
+    def glue_group(self, name: str) -> None:
+        """Move windows from another group to this one."""
+        assert self.qtile is not None
+        other = self.qtile.groups_map.get(name)
+        if not other or other is self:
+            return
+        for w in list(other.windows):
+            self.glue_map[w] = other
+            w.togroup(self.name)
+
+    @expose_command()
+    def unglue_group(self) -> None:
+        """Return windows glued to this group to their original group."""
+        for w, original in list(self.glue_map.items()):
+            if w.group is self:
+                w.togroup(original.name)
+            self.glue_map.pop(w, None)
+
     def __repr__(self):
         return f"<group.Group ({self.name!r})>"
+
+
+def _clear_glue(group: _Group, window) -> None:
+    group.glue_map.pop(window, None)
+
+
+hook.subscribe.group_window_remove(_clear_glue)

--- a/libqtile/resources/default_config.py
+++ b/libqtile/resources/default_config.py
@@ -120,6 +120,14 @@ for i in groups:
         ]
     )
 
+# Example key bindings to glue and unglue groups
+keys.extend(
+    [
+        Key([mod], "g", lazy.group.glue_group("9"), desc="Glue group 9 to current"),
+        Key([mod], "u", lazy.group.unglue_group(), desc="Unglue windows from group"),
+    ]
+)
+
 layouts = [
     layout.Columns(border_focus_stack=["#d75f5f", "#8f3d3d"], border_width=4),
     layout.Max(),


### PR DESCRIPTION
## Summary
- add new `glue_map` to `_Group`
- implement `glue_group` and `unglue_group` commands
- clean up glue map when windows leave groups
- document commands in manual and add default keybindings

## Testing
- `pre-commit run --files libqtile/group.py docs/manual/config/lazy.rst libqtile/resources/default_config.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cairocffi')*

------
https://chatgpt.com/codex/tasks/task_e_684b42a01bac8328b773edfdbc57611a